### PR TITLE
Add label for bibliography search input

### DIFF
--- a/_includes/bib_search.liquid
+++ b/_includes/bib_search.liquid
@@ -1,4 +1,7 @@
 {% if site.bib_search %}
   <script src="{{ '/assets/js/bibsearch.js' | relative_url | bust_file_cache }}" type="module"></script>
-  <input type="text" id="bibsearch" spellcheck="false" autocomplete="off" class="search bibsearch-form-input" placeholder="Type to filter">
+  <label for="bibsearch" class="bibsearch-label">
+    Filter publications
+    <input type="text" id="bibsearch" spellcheck="false" autocomplete="off" class="search bibsearch-form-input" placeholder="Type to filter">
+  </label>
 {% endif %}

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -1218,6 +1218,12 @@ ninja-keys::part(ninja-input-wrapper) {
   border-color: var(--global-theme-color) !important;
 }
 
+.bibsearch-label {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+}
+
 .newsletter-form-button {
   background: var(--global-theme-color);
   color: var(--global-bg-color);


### PR DESCRIPTION
## Summary
- improve accessibility of bibliography search input by adding a visible label
- add basic styling for bibliography search label

## Testing
- `npm test` *(fails: Missing script "test")*
- `pre-commit run --files _includes/bib_search.liquid _sass/_base.scss`


------
https://chatgpt.com/codex/tasks/task_e_689b126656608330b12e9be51809be8e