### PR TITLE
chore: lazy load bib thumbnails

### DIFF
--- a/_layouts/bib.liquid
+++ b/_layouts/bib.liquid
@@ -32,13 +32,13 @@
           {% assign entry_path = entry.preview | prepend: '/assets/img/publication_preview/' %}
           {%
             include figure.liquid
-            loading="eager"
+            loading="lazy"
             path=entry_path
             sizes = "200px"
             class="preview z-depth-1 rounded"
             zoomable=true
             avoid_scaling=true
-            alt=entry.preview
+            alt=entry.title
           %}
         {% endif %}
       {% endif %}


### PR DESCRIPTION
## Summary
- lazy-load bibliography preview images
- describe thumbnails with publication titles

## Testing
- `bundle exec jekyll build` *(fails: convert not found; 403 "Forbidden" when fetching Twitter data)*

------
https://chatgpt.com/codex/tasks/task_e_689b1d6cb4388330a7fa13babb409e5f